### PR TITLE
small fixes to import path in example notebooks and to flow profiler

### DIFF
--- a/docs/example_notebooks/example_chains_convergence_test.ipynb
+++ b/docs/example_notebooks/example_chains_convergence_test.ipynb
@@ -25,6 +25,8 @@
    "source": [
     "# we start by importing several libraries:\n",
     "import sys, os\n",
+    "os.environ['TF_USE_LEGACY_KERAS'] = '1'  # needed for tensorflow KERAS compatibility\n",
+    "os.environ['DISPLAY'] = 'inline'  # hack to get getdist working\n",
     "sys.path.insert(0,os.path.realpath(os.path.join(os.getcwd(),'../..')))\n",
     "from getdist import plots, MCSamples\n",
     "from getdist.gaussian_mixtures import GaussianND\n",
@@ -55,9 +57,9 @@
    "outputs": [],
    "source": [
     "# load the chains (remove no burn in since the example chains have already been cleaned):\n",
-    "chains_dir = './../../test_chains/'\n",
+    "chains_dir = os.path.realpath(os.path.join(os.getcwd(), '../..', 'test_chains'))\n",
     "# the DES Y1 3x2 chain:\n",
-    "chain = getdist.mcsamples.loadMCSamples(file_root=chains_dir+'DES', no_cache=True)"
+    "chain = getdist.mcsamples.loadMCSamples(file_root=os.path.join(chains_dir, 'DES'), no_cache=True)"
    ]
   },
   {
@@ -499,7 +501,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "tensiometer",
    "language": "python",
    "name": "python3"
   },
@@ -513,7 +515,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/example_notebooks/example_gaussian_tension.ipynb
+++ b/docs/example_notebooks/example_gaussian_tension.ipynb
@@ -26,6 +26,8 @@
     "%autoreload 1\n",
     "# import libraries:\n",
     "import sys, os\n",
+    "os.environ['TF_USE_LEGACY_KERAS'] = '1'  # needed for tensorflow KERAS compatibility\n",
+    "os.environ['DISPLAY'] = 'inline'  # hack to get getdist working\n",
     "sys.path.insert(0,os.path.realpath(os.path.join(os.getcwd(),'../..')))\n",
     "from getdist import plots, MCSamples\n",
     "from getdist.gaussian_mixtures import GaussianND\n",
@@ -281,15 +283,15 @@
    "outputs": [],
    "source": [
     "# load the samples (remove no burn in since the example chains have already been cleaned):\n",
-    "chains_dir = './../../test_chains/'\n",
+    "chains_dir = os.path.realpath(os.path.join(os.getcwd(), '../..', 'test_chains'))\n",
     "# the Planck 2018 TTTEEE chain:\n",
-    "chain_1 = getdist.mcsamples.loadMCSamples(file_root=chains_dir+'Planck18TTTEEE', no_cache=True)\n",
+    "chain_1 = getdist.mcsamples.loadMCSamples(file_root=os.path.join(chains_dir, 'Planck18TTTEEE'), no_cache=True)\n",
     "# the DES Y1 3x2 chain:\n",
-    "chain_2 = getdist.mcsamples.loadMCSamples(file_root=chains_dir+'DES', no_cache=True)\n",
+    "chain_2 = getdist.mcsamples.loadMCSamples(file_root=os.path.join(chains_dir, 'DES'), no_cache=True)\n",
     "# the joint chain:\n",
-    "chain_12 = getdist.mcsamples.loadMCSamples(file_root=chains_dir+'Planck18TTTEEE_DES', no_cache=True)\n",
+    "chain_12 = getdist.mcsamples.loadMCSamples(file_root=os.path.join(chains_dir, 'Planck18TTTEEE_DES'), no_cache=True)\n",
     "# the prior chain:\n",
-    "prior_chain = getdist.mcsamples.loadMCSamples(file_root=chains_dir+'prior', no_cache=True)"
+    "prior_chain = getdist.mcsamples.loadMCSamples(file_root=os.path.join(chains_dir, 'prior'), no_cache=True)"
    ]
   },
   {
@@ -557,7 +559,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "tensiometer",
    "language": "python",
    "name": "python3"
   },
@@ -571,7 +573,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/example_notebooks/example_measured_parameters.ipynb
+++ b/docs/example_notebooks/example_measured_parameters.ipynb
@@ -34,6 +34,8 @@
     "\n",
     "# import libraries:\n",
     "import sys, os\n",
+    "os.environ['TF_USE_LEGACY_KERAS'] = '1'  # needed for tensorflow KERAS compatibility\n",
+    "os.environ['DISPLAY'] = 'inline'  # hack to get getdist working\n",
     "sys.path.insert(0,os.path.realpath(os.path.join(os.getcwd(),'../..')))\n",
     "from getdist import plots, MCSamples\n",
     "from getdist.gaussian_mixtures import GaussianND\n",
@@ -70,12 +72,12 @@
    "outputs": [],
    "source": [
     "# load the chains (remove no burn in since the example chains have already been cleaned):\n",
-    "chains_dir = './../../test_chains/'\n",
+    "chains_dir = os.path.realpath(os.path.join(os.getcwd(), '../..', 'test_chains'))\n",
     "# the DES Y1 3x2 chain:\n",
     "settings = {'ignore_rows':0, 'smooth_scale_1D':0.3, 'smooth_scale_2D':0.3}\n",
-    "chain = getdist.mcsamples.loadMCSamples(file_root=chains_dir+'DES', no_cache=True, settings=settings)\n",
+    "chain = getdist.mcsamples.loadMCSamples(file_root=os.path.join(chains_dir, 'DES'), no_cache=True, settings=settings)\n",
     "# the prior chain:\n",
-    "prior_chain = getdist.mcsamples.loadMCSamples(file_root=chains_dir+'prior', no_cache=True, settings=settings)\n",
+    "prior_chain = getdist.mcsamples.loadMCSamples(file_root=os.path.join(chains_dir, 'prior'), no_cache=True, settings=settings)\n",
     "\n",
     "# we add a couple of derived parameters that have been removed from the chains (to save a little space on github):\n",
     "for ch in [chain, prior_chain]:\n",
@@ -617,7 +619,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "tensiometer",
    "language": "python",
    "name": "python3"
   },
@@ -631,7 +633,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/example_notebooks/example_non_gaussian_tension.ipynb
+++ b/docs/example_notebooks/example_non_gaussian_tension.ipynb
@@ -27,6 +27,8 @@
     "%autoreload 1\n",
     "# import libraries:\n",
     "import sys, os\n",
+    "os.environ['TF_USE_LEGACY_KERAS'] = '1'  # needed for tensorflow KERAS compatibility\n",
+    "os.environ['DISPLAY'] = 'inline'  # hack to get getdist working\n",
     "sys.path.insert(0,os.path.realpath(os.path.join(os.getcwd(),'../..')))\n",
     "from getdist import plots\n",
     "import getdist\n",
@@ -54,11 +56,11 @@
    "outputs": [],
    "source": [
     "# load the samples (remove no burn in since the example chains have already been cleaned):\n",
-    "chains_dir = './../../test_chains/'\n",
+    "chains_dir = os.path.realpath(os.path.join(os.getcwd(), '../..', 'test_chains'))\n",
     "# the Planck 2018 TTTEEE chain:\n",
-    "chain_1 = getdist.mcsamples.loadMCSamples(file_root=chains_dir+'Planck18TTTEEE', no_cache=True)\n",
+    "chain_1 = getdist.mcsamples.loadMCSamples(file_root=os.path.join(chains_dir, 'Planck18TTTEEE'), no_cache=True)\n",
     "# the DES Y1 3x2 chain:\n",
-    "chain_2 = getdist.mcsamples.loadMCSamples(file_root=chains_dir+'DES', no_cache=True)"
+    "chain_2 = getdist.mcsamples.loadMCSamples(file_root=os.path.join(chains_dir, 'DES'), no_cache=True)"
    ]
   },
   {
@@ -463,7 +465,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "tensiometer",
    "language": "python",
    "name": "python3"
   },
@@ -477,7 +479,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/example_notebooks/example_posterior_profiles.ipynb
+++ b/docs/example_notebooks/example_posterior_profiles.ipynb
@@ -36,6 +36,8 @@
     "\n",
     "# import libraries:\n",
     "import sys, os\n",
+    "os.environ['TF_USE_LEGACY_KERAS'] = '1'  # needed for tensorflow KERAS compatibility\n",
+    "os.environ['DISPLAY'] = 'inline'  # hack to get getdist working\n",
     "sys.path.insert(0,os.path.realpath(os.path.join(os.getcwd(),'../..')))\n",
     "from getdist import plots, MCSamples\n",
     "from getdist.gaussian_mixtures import GaussianND\n",
@@ -469,9 +471,9 @@
     "# we start by loading up the posterior:\n",
     "\n",
     "# load the samples (remove no burn in since the example chains have already been cleaned):\n",
-    "chains_dir = './../../test_chains/'\n",
+    "chains_dir = os.path.realpath(os.path.join(os.getcwd(), '../..', 'test_chains'))\n",
     "# the DES Y1 3x2 chain:\n",
-    "data_chain = getdist.mcsamples.loadMCSamples(file_root=chains_dir+'DES', no_cache=True, settings=getdist_settings)\n",
+    "data_chain = getdist.mcsamples.loadMCSamples(file_root=os.path.join(chains_dir, 'DES'), no_cache=True, settings=getdist_settings)\n",
     "\n",
     "# let's add omegab as a derived parameter:\n",
     "for _ch in [data_chain]:\n",
@@ -889,7 +891,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "mlg",
    "language": "python",
    "name": "python3"
   },
@@ -903,7 +905,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/docs/example_notebooks/example_synthetic_probability.ipynb
+++ b/docs/example_notebooks/example_synthetic_probability.ipynb
@@ -32,6 +32,8 @@
     "\n",
     "# import libraries:\n",
     "import sys, os\n",
+    "os.environ['TF_USE_LEGACY_KERAS'] = '1'  # needed for tensorflow KERAS compatibility\n",
+    "os.environ['DISPLAY'] = 'inline'  # hack to get getdist working\n",
     "sys.path.insert(0,os.path.realpath(os.path.join(os.getcwd(),'../..')))\n",
     "from getdist import plots, MCSamples\n",
     "from getdist.gaussian_mixtures import GaussianND\n",
@@ -380,13 +382,13 @@
     "# we start by loading up the posteriors:\n",
     "\n",
     "# load the samples (remove no burn in since the example chains have already been cleaned):\n",
-    "chains_dir = './../../test_chains/'\n",
+    "chains_dir = os.path.realpath(os.path.join(os.getcwd(), '../..', 'test_chains'))\n",
     "# the Planck 2018 TTTEEE chain:\n",
-    "chain_1 = getdist.mcsamples.loadMCSamples(file_root=chains_dir+'Planck18TTTEEE', no_cache=True, settings=getdist_settings)\n",
+    "chain_1 = getdist.mcsamples.loadMCSamples(file_root=os.path.join(chains_dir, 'Planck18TTTEEE'), no_cache=True, settings=getdist_settings)\n",
     "# the DES Y1 3x2 chain:\n",
-    "chain_2 = getdist.mcsamples.loadMCSamples(file_root=chains_dir+'DES', no_cache=True, settings=getdist_settings)\n",
+    "chain_2 = getdist.mcsamples.loadMCSamples(file_root=os.path.join(chains_dir, 'DES'), no_cache=True, settings=getdist_settings)\n",
     "# the joint chain:\n",
-    "chain_12 = getdist.mcsamples.loadMCSamples(file_root=chains_dir+'Planck18TTTEEE_DES', no_cache=True, settings=getdist_settings)\n",
+    "chain_12 = getdist.mcsamples.loadMCSamples(file_root=os.path.join(chains_dir, 'Planck18TTTEEE_DES'), no_cache=True, settings=getdist_settings)\n",
     "\n",
     "# let's add omegab as a derived parameter:\n",
     "for _ch in [chain_1, chain_2, chain_12]:\n",
@@ -463,7 +465,7 @@
     "# now we can define the joint posterior:\n",
     "def joint_log_posterior(H0, omegam, sigma8, ns, omegab):\n",
     "    params = [H0, omegam, sigma8, ns, omegab]\n",
-    "    return [flow_1.log_probability(flow_1.cast(params)).numpy() + flow_2.log_probability(flow_2.cast(params)).numpy()]\n",
+    "    return [flow_1.log_probability(flow_1.cast([params])).numpy()[0] + flow_2.log_probability(flow_2.cast([params])).numpy()[0]]\n",
     "\n",
     "# and sample it:\n",
     "from cobaya.run import run\n",
@@ -937,7 +939,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "mlg",
    "language": "python",
    "name": "python3"
   },
@@ -951,7 +953,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/tensiometer/synthetic_probability/flow_profiler.py
+++ b/tensiometer/synthetic_probability/flow_profiler.py
@@ -816,6 +816,7 @@ class posterior_profile_plotter(mcsamples.MCSamples):
         m.complexity = 2 * (maxlike - m.meanLogLike)
         m.logMeanInvLike = np.log(np.mean(np.exp(-_temp_loglikes + maxlike))) - maxlike
         m.logMeanLike = -np.log(np.mean(np.exp(_temp_loglikes - maxlike))) + maxlike
+        m.varLogLike = np.var(_temp_loglikes)
         m.names = self.paramNames.names
 
         if profile_lims:


### PR DESCRIPTION
When running the example notebooks from a non-standard path, the previous import would fail. This commit resolves the issue by referencing the notebook's own path.

Additionally:
• added settings for TensorFlow Keras compatibility;
• ensured inline plotting to make GetDist work properly;
• added computation of the variance of log-likelihoods to support the recent update in GetDist.